### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.374.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.19.2
-	github.com/alexfalkowski/go-service/v2 v2.373.0
+	github.com/alexfalkowski/go-service/v2 v2.374.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.2 h1:wsqGEevu5mF0+/3QNABgB7R2gpGk4j9fwuMtbzIVzuo=
 github.com/alexfalkowski/go-health/v2 v2.19.2/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.373.0 h1:dH/rvg43aWNHyFaEghFNfG7SKN+p32DSyqYEyknOKZs=
-github.com/alexfalkowski/go-service/v2 v2.373.0/go.mod h1:DqZ5L3CK3ThEP5hcGqmzskjAdyhxOY7iO7TAZk5FlL4=
+github.com/alexfalkowski/go-service/v2 v2.374.0 h1:Oxn+hf792PBnogBXtyo3/fadN84KIVd50ZOQXaIu06E=
+github.com/alexfalkowski/go-service/v2 v2.374.0/go.mod h1:HR3A5tYH1RBCkuocmOSa+xb3qYgLjqHLTnuQVuvyKeA=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.374.0
