### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.427.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.21.0
-	github.com/alexfalkowski/go-service/v2 v2.424.0
+	github.com/alexfalkowski/go-service/v2 v2.427.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.21.0 h1:eS1+ixrIvn5C0tl7Q41yICNI5NR+dZ2xGbrQ1lOd59k=
 github.com/alexfalkowski/go-health/v2 v2.21.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.424.0 h1:sBIKHATfwFb6YabyoNUuVlh9UwuKVudBTqPl3TJLlYA=
-github.com/alexfalkowski/go-service/v2 v2.424.0/go.mod h1:QlHN8vPFu0/1j2DzzjURsflt1DvLWcRgFlZYFzc7CG4=
+github.com/alexfalkowski/go-service/v2 v2.427.0 h1:P32yvMllooLd2h/v0O8z3QqEbGVuTxpT/jU/3fCghwQ=
+github.com/alexfalkowski/go-service/v2 v2.427.0/go.mod h1:QlHN8vPFu0/1j2DzzjURsflt1DvLWcRgFlZYFzc7CG4=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.427.0
