### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.501.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.23.0
-	github.com/alexfalkowski/go-service/v2 v2.500.0
+	github.com/alexfalkowski/go-service/v2 v2.501.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.23.0 h1:fYAMpjTneRsi4h8mrvGseTeErYJlh96LK4aMcKs52O0=
 github.com/alexfalkowski/go-health/v2 v2.23.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.500.0 h1:KP6GOA2YzIPd1/Lx0Acjwzby1/cT7+2Wf4C/mpzXzh4=
-github.com/alexfalkowski/go-service/v2 v2.500.0/go.mod h1:sp7S2eJ8yMMQRGAPOKOxRWd2fW3JCyecTFAypvh36U0=
+github.com/alexfalkowski/go-service/v2 v2.501.0 h1:ohjJgli/74PejdJ+laXXb4haDXOp1BLZ/LMLm4ui4zM=
+github.com/alexfalkowski/go-service/v2 v2.501.0/go.mod h1:sp7S2eJ8yMMQRGAPOKOxRWd2fW3JCyecTFAypvh36U0=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.501.0
