### PR TITLE
build(ci): serialize docker manifest releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,7 @@ workflows:
               only: master
       - manifest-docker:
           context: docker
+          serial-group: << pipeline.project.slug >>/manifest-docker
           requires:
             - release-docker-amd64
             - release-docker-arm64


### PR DESCRIPTION
## What

- Serialize the CircleCI `manifest-docker` workflow job with `<< pipeline.project.slug >>/manifest-docker`.
- Keep the existing Docker context, branch filter, and architecture release dependencies unchanged.

## Why

- Prevent overlapping master pipelines from publishing the mutable `latest` Docker manifest out of order after the amd64 and arm64 images are pushed.
- Keep versioned image tags as the deployment contract while making the convenience manifest less race-prone.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `git diff --check` - passed
