### PR TITLE
build(project): surface child makefile help

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/buf.mak

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak


### PR DESCRIPTION
## What

- Add shared help wiring to the `api` and `test` child Makefiles.
- Preserve existing Buf and Ruby targets in those directories.

## Why

- The child directories expose real workflow targets but did not support direct help discovery.
- Adding help keeps those sub-workflows consistent with the root Makefile and sibling service repositories.

## Testing

- `gmake -C api help` - passed.
- `gmake -C test help` - passed.
