### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.600.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.29.0
-	github.com/alexfalkowski/go-service/v2 v2.599.0
+	github.com/alexfalkowski/go-service/v2 v2.600.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.29.0 h1:ZXkXalGX4u5DZR6eZAySpXCb1UUAvq+ufD1Eq+kKUv8=
 github.com/alexfalkowski/go-health/v2 v2.29.0/go.mod h1:oIzLvkIhiXUbPSYQRW2Gezah+sW+ZEY9BcoOi/5Agxo=
-github.com/alexfalkowski/go-service/v2 v2.599.0 h1:CjDVCEANk8lQft0It4MZ0DWKx1mE3E07VOAID0bmH/k=
-github.com/alexfalkowski/go-service/v2 v2.599.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
+github.com/alexfalkowski/go-service/v2 v2.600.0 h1:bKgrhZVijD1q5Kd4ZyKv3J7NGNnf+VBML/WEOZZPO+s=
+github.com/alexfalkowski/go-service/v2 v2.600.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
 github.com/alexfalkowski/go-sync v1.24.0 h1:CrV+LITc8C78v01u9ATGvIgipmNtJlZWGWW1znFsdjM=
 github.com/alexfalkowski/go-sync v1.24.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.600.0
