### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.653.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.33.0
-	github.com/alexfalkowski/go-service/v2 v2.652.0
+	github.com/alexfalkowski/go-service/v2 v2.653.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.652.0 h1:uoswB4FZ6aYYOCoOQlurpFp+Z/+aCJjEnbnZp7INt04=
-github.com/alexfalkowski/go-service/v2 v2.652.0/go.mod h1:OhKGfqh+sajgQBwogfmtQWqaWegZVquO+62uq5bFqCg=
+github.com/alexfalkowski/go-service/v2 v2.653.0 h1:azcdTjVEbZhlcw5DzFBvAwGzSJQIO+pRq7wWsrK3iPs=
+github.com/alexfalkowski/go-service/v2 v2.653.0/go.mod h1:OhKGfqh+sajgQBwogfmtQWqaWegZVquO+62uq5bFqCg=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    sorbet-runtime (0.6.13328)
+    sorbet-runtime (0.6.13329)
     ssh_data (1.3.0)
     sys-uname (1.5.1)
       ffi (~> 1.1)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.653.0
