### PR TITLE
docs(shared-agent-guidance): add root policy pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Shared guidance
+
+Use `bin/AGENTS.md` for shared skills and cross-repository defaults.


### PR DESCRIPTION
## What

- Add a minimal root `AGENTS.md` pointer to the shared `bin/AGENTS.md` policy and skills.
- Leave repository-specific instructions, Makefiles, CI, Claude wiring, and Codex symlinks unchanged.

## Why

- This template already exposes shared guidance to Claude and shared skills to Codex, but Codex needs a root `AGENTS.md` entrypoint to discover the canonical policy on fresh clones. The pointer aligns this template with the other shared-bin consumers without duplicating policy.

## Testing

- `make help` - passed; confirmed the repository command surface.
- `git diff --no-index --check /dev/null AGENTS.md` - passed with no whitespace diagnostics.
- Static wiring checks passed for `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, and `.claude/skills`.
- No executable tests were run; this is a five-line agent-guidance pointer change with no product behavior changes.
