### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.756.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.38.0
-	github.com/alexfalkowski/go-service/v2 v2.755.0
+	github.com/alexfalkowski/go-service/v2 v2.756.0
 	go.uber.org/fx v1.24.0
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.38.0 h1:3u8OmitF/iNqlHt+VkDcH4CKWM2IXczSmhC/MwFKIAo=
 github.com/alexfalkowski/go-health/v2 v2.38.0/go.mod h1:ImlmOirOv5tqt6sFJnJdpzRX8Y2tqH4Zz3FADTsPVV4=
-github.com/alexfalkowski/go-service/v2 v2.755.0 h1:GAThxpsq43K3ENyRfb3aVTSzefBpDMLIE/gwTBmYaa8=
-github.com/alexfalkowski/go-service/v2 v2.755.0/go.mod h1:0lyAO00kyn3EMX1vYpXCno/fczJNpOwVrhBaFUXTDZA=
+github.com/alexfalkowski/go-service/v2 v2.756.0 h1:1zj/HBN2OBZ1lofY0p0VCjMsAp8cTDgsgANV0b8gCGg=
+github.com/alexfalkowski/go-service/v2 v2.756.0/go.mod h1:0lyAO00kyn3EMX1vYpXCno/fczJNpOwVrhBaFUXTDZA=
 github.com/alexfalkowski/go-sync v1.33.0 h1:XN5XUFJ/w/emDUJ0CXZOZl6UVTkx/zj0y6kaFWIHbk8=
 github.com/alexfalkowski/go-sync v1.33.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.756.0
